### PR TITLE
Update start-containers.sh

### DIFF
--- a/start-containers.sh
+++ b/start-containers.sh
@@ -13,7 +13,7 @@ echo "Creating VM: ${VM_NAME}"
 gcloud compute instances create ${VM_NAME} \
   --tags ${VM_NAME} \
   --zone ${ZONE}  --machine-type ${MACHINE_TYPE} \
-  --image projects/google-containers/global/images/container-vm-v20140522 \
+  --image https://www.googleapis.com/compute/v1/projects/google-containers/global/images/container-vm-v20140522 \
   --metadata-from-file google-container-manifest=manifest.yaml
 
 wait_vm_ready


### PR DESCRIPTION
It appears that gcloud now requires the full HTTP path for public images.
