### PR TITLE
Make manifest.yaml conform to Kubelet

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,4 +1,5 @@
 version: v1beta2
+id: container-vm-guestbook
 containers:
   - name: redis
     image: dockerfile/redis


### PR DESCRIPTION
Kubelet expects an ID at the manifest scope.
